### PR TITLE
Allow for compatibility with Haml in XHTML output format

### DIFF
--- a/app/helpers/dismissible_blocks_helper.rb
+++ b/app/helpers/dismissible_blocks_helper.rb
@@ -2,7 +2,7 @@ module DismissibleBlocksHelper
   def render_dismissible_block(name, &block)
     unless dismissed?(name)
       if block_given?
-        contents = capture(&block)
+        contents = capture(name, &block)
         add_block_name_to_attributes(contents, name)
       else
         raise DismissibleBlocks::ContentMissing
@@ -27,7 +27,7 @@ module DismissibleBlocksHelper
     end
 
     def add_block_name_to_attributes(contents, name)
-      contents.gsub! /(data-dismissible)(-hide)?(?!-)/, "\\1\\2='#{name}'"
+      contents.gsub! /(data-dismissible)(-hide)?(?![-=])/, "\\1\\2='#{name}'"
       contents.html_safe
     end
 end

--- a/test/helpers/dismissible_blocks_helper_test.rb
+++ b/test/helpers/dismissible_blocks_helper_test.rb
@@ -47,7 +47,27 @@ class DismissibleBlocksHelperTest < ActionView::TestCase
     block += '</div>'
     def self.current_user; users(:one); end
     html = render_dismissible_block('lorem') { block.html_safe }
-    assert html.include? "data-dismissible='lorem'"
-    assert html.include? "data-dismissible-hide='lorem'"
+    assert_includes html, "data-dismissible='lorem'"
+    assert_includes html, "data-dismissible-hide='lorem'"
+  end
+
+  test "does not modify data attributes that already have values" do
+    block  = "<div data-dismissible='ipsum'>"
+    block += "<span data-dismissible-hide='ipsum'></span>"
+    block += "</div>"
+    def self.current_user; users(:one); end
+    html = render_dismissible_block('lorem') { block.html_safe }
+    assert_includes html, "data-dismissible='ipsum'"
+    assert_includes html, "data-dismissible-hide='ipsum'"
+  end
+
+  test "yields name to the content block" do
+    def self.current_user; users(:one); end
+    passed_name = nil
+    render_dismissible_block('lorem') do |name|
+      passed_name = name
+      'ipsum'
+    end
+    assert_equal 'lorem', passed_name
   end
 end


### PR DESCRIPTION
This PR changes `DismissibleBlocksHelper#add_block_name_to_attributes` to ignore data attributes with existing values.

As a convenience, the name of the dismissible block is yielded to the content block for use when building attribute values.
## Details

We just started using dismissible_blocks in our app at cultureamp.com. Thanks for the gem!

We have Haml configured to output in XHTML format, which trips up the helper. XHTML doesn't allow "bare" attributes without a value, so Haml like this:

``` haml
= render_dismissible_block 'report_sharing_intro' do
  .card(data-dismissible)
    -# ...etc...
```

...generates a contents block like this in XHTML mode:

``` html
<div class='card' data-dismissible='data-dismissible'>
<!-- ...etc... -->
```

...which gets mis-parsed by the regex in `DismissibleBlocksHelper#add_block_name_to_attributes` and turned into this:

``` html
<div class='card' data-dismissible='report_sharing_intro'='data-dismissible='report_sharing_intro''>
<!-- ...etc... -->
```

My first thought was to make the regex optionally capture and replace the value if it's there, but then I thought it would be simpler overall to generate the data attributes with the correct value in the first place, and then leave them alone in the helper.

It also passes `name` to the content block to avoid having to hardcode it multiple times. The resulting code looks like this:

``` haml
= render_dismissible_block 'report_sharing_intro' do |dismissible|
  .card(data-dismissible=dismissible)
    -# ...etc...
```

What do you think? The drawback to this approach vs. substituting the value in the helper is that it would be possible to accidentally create a mis-match between the name passed to the helper and the name in the HTML, but if you take advantage of the yielded name, you can avoid that.

It remains backward-compatible with existing uses that have no attribute value.
