### PR TITLE
Prod 2793 modify dismissible blocks gem fork

### DIFF
--- a/app/controllers/dismissible_blocks_controller.rb
+++ b/app/controllers/dismissible_blocks_controller.rb
@@ -1,5 +1,5 @@
 class DismissibleBlocksController < ApplicationController
-  allows_access_to :anonymous_users
+  allows_access_to :all_authenticated_users
   def create
     if current_user_available
       current_user.dismissed_blocks += [ params[:block].to_s ]

--- a/app/controllers/dismissible_blocks_controller.rb
+++ b/app/controllers/dismissible_blocks_controller.rb
@@ -1,4 +1,5 @@
 class DismissibleBlocksController < ApplicationController
+  allows_access_to :anonymous_users
   def create
     if current_user_available
       current_user.dismissed_blocks += [ params[:block].to_s ]


### PR DESCRIPTION
Modifies the gem controller to allow access to all authenticated users (as per new auth framework). To be read in conjunction with [Prod 2793 cant dismiss tooltip ie9](https://github.com/cultureamp/murmur/pull/10)
